### PR TITLE
fix(readme.md): fix yarn install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Requirements:
 
 ### Usage
 
-1. Install dependencies `yarn i`
+1. Install dependencies `yarn install`
 2. Start dev server `yarn run dev` open [http://localhost:2992](http://localhost:2992)
 3. Lint your code `yarn run lint`
 4. Run unit tests `yarn run test`


### PR DESCRIPTION
`yarn i` is not available on yarn. it uses whether `yarn install` (some people say its deprecated) or just `yarn`
I made it `yarn install`, because I thought it may cause confusion for some beginners.
take a look at these and decide for yourself to whether make it `yarn` or `yarn install`:
https://github.com/yarnpkg/yarn/issues/1683
https://github.com/yarnpkg/yarn/issues/649
https://github.com/yarnpkg/yarn/issues/3398

`yarn i ` results in this : 
![yarni](https://user-images.githubusercontent.com/5755214/31952085-9e4972f8-b8ec-11e7-9ca2-98139d4b33a1.PNG)

+thanks for the great seed. Keep up the good work :)